### PR TITLE
fix color precision

### DIFF
--- a/pomodoro/PomodoroColorProvider.swift
+++ b/pomodoro/PomodoroColorProvider.swift
@@ -2,10 +2,10 @@
 import SwiftUI
 
 struct PomodoroColorProvider {
-    static let background = Color(red: 13/255, green: 4/255, blue: 4/255)
-    static let focus = Color(red: 1.0, green: 76/255, blue: 76/255) // 赤系
-    static let shortBreak = Color(red: 77/255, green: 218/255, blue: 110/255) // 緑系
-    static let longBreak = Color(red: 76/255, green: 172/255, blue: 1.0) // 青系
+    static let background = Color(red: 13.0 / 255.0, green: 4.0 / 255.0, blue: 4.0 / 255.0)
+    static let focus = Color(red: 1.0, green: 76.0 / 255.0, blue: 76.0 / 255.0) // 赤系
+    static let shortBreak = Color(red: 77.0 / 255.0, green: 218.0 / 255.0, blue: 110.0 / 255.0) // 緑系
+    static let longBreak = Color(red: 76.0 / 255.0, green: 172.0 / 255.0, blue: 1.0) // 青系
     static let pause = Color.orange
     static let reset = Color.gray.opacity(0.5)
     static let timerText = Color.white


### PR DESCRIPTION
## Summary
- use floating point division in PomodoroColorProvider color definitions

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1a2f14b4832290d6cc1915badb76