### PR TITLE
Fix typo in test function name

### DIFF
--- a/pomodoroTests/pomodoroTests.swift
+++ b/pomodoroTests/pomodoroTests.swift
@@ -119,7 +119,7 @@ struct PomodoroTimerViewModelTests {
     // MARK: - Pomodoro Cycle Tests
 
     @Test("完全なポモドーロサイクル")
-    func completePomodorooCycle() {
+    func completePomodoroCycle() {
         let viewModel = PomodoroTimerViewModel()
 
         // 1回目: フォーカス → ショートブレーク


### PR DESCRIPTION
## Summary
- rename `completePomodorooCycle` to `completePomodoroCycle` in tests

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684e1a249f78832295569d709971c9de