### PR TITLE
Add fallback test for undefined language

### DIFF
--- a/pomodoroTests/pomodoroTests.swift
+++ b/pomodoroTests/pomodoroTests.swift
@@ -241,6 +241,19 @@ struct PomodoroTimerViewModelTests {
 
         #expect(viewModel.t(nonExistentKey) == nonExistentKey)
     }
+
+    @Test("未定義言語は英語にフォールバック")
+    func undefinedLanguageFallbackToEnglish() {
+        let viewModel = PomodoroTimerViewModel()
+        viewModel.language = "fr"  // 定義されていない言語
+
+        #expect(viewModel.t("focus") == "Focus")
+        #expect(viewModel.t("shortBreak") == "Short Break")
+        #expect(viewModel.t("longBreak") == "Long Break")
+        #expect(viewModel.t("start") == "Start")
+        #expect(viewModel.t("pause") == "Pause")
+        #expect(viewModel.t("reset") == "Reset")
+    }
 }
 
 // MARK: - Color Provider Tests


### PR DESCRIPTION
## Summary
- ensure `PomodoroTimerViewModel` falls back to English when language is unknown

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684e1aee7eb483229ccd1e8c6c15391b